### PR TITLE
fix: correct memory limit detection for cgroup v1 and v2

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 		for {
 			workQueue <- struct{}{}
 			go func() {
-				cmd := exec.Command("memStress", "--size", memSize, "--workers", fmt.Sprintf("%d", workers),
+				cmd := exec.Command("./memStress", "--size", memSize, "--workers", fmt.Sprintf("%d", workers),
 					"--time", growthTime, "--client", "1")
 				cmd.SysProcAttr = &syscall.SysProcAttr{
 					Pdeathsig: syscall.SIGTERM,

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
-	psutil "github.com/shirou/gopsutil/mem"
 )
 
 var (
@@ -114,7 +113,11 @@ func main() {
 			time.Sleep(time.Second)
 		}
 	} else {
-		memInfo, _ := psutil.VirtualMemory()
+		totalMem, err := getTotalMemory()
+		if err != nil {
+			fmt.Println("get total memory err:", err)
+			return
+		}
 		var length uint64
 
 		if memSize[len(memSize)-1] != '%' {
@@ -129,7 +132,7 @@ func main() {
 			if err != nil {
 				fmt.Println(err)
 			}
-			length = uint64(float64(memInfo.Total) / 100.0 * percentage)
+			length = uint64(float64(totalMem) / 100.0 * percentage)
 		}
 
 		timeLine, err := time.ParseDuration(growthTime)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	psutil "github.com/shirou/gopsutil/mem"
+)
+
+const (
+	cgroupV2Path    = "/sys/fs/cgroup/memory.max"
+	cgroupV1Path    = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	cgroupNoLimitV1 = 0x7FFFFFFFFFFFF000
+)
+
+// Read file content and parse as uint64
+func readUintFromFile(path string) (uint64, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	content := strings.TrimSpace(string(data))
+	return strconv.ParseUint(content, 10, 64)
+}
+
+// Check cgroup v2 memory limit
+func getCgroupV2Limit() (uint64, error) {
+	data, err := ioutil.ReadFile(cgroupV2Path)
+	if err != nil {
+		return 0, err
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "max" {
+		return 0, fmt.Errorf("cgroup v2: no memory limit set")
+	}
+	limit, err := strconv.ParseUint(content, 10, 64)
+	if err != nil || limit == 0 {
+		return 0, fmt.Errorf("cgroup v2: invalid memory limit")
+	}
+	return limit, nil
+}
+
+// Check cgroup v1 memory limit
+func getCgroupV1Limit() (uint64, error) {
+	limit, err := readUintFromFile(cgroupV1Path)
+	if err != nil {
+		return 0, err
+	}
+	// 0 or cgroup's "infinity" value means no limit
+	if limit == 0 || limit >= cgroupNoLimitV1 {
+		return 0, fmt.Errorf("cgroup v1: no memory limit set")
+	}
+	return limit, nil
+}
+
+// Get total memory, prefer cgroup v2 -> cgroup v1 -> host
+func getTotalMemory() (uint64, error) {
+	if limit, err := getCgroupV2Limit(); err == nil {
+		return limit, nil
+	}
+	if limit, err := getCgroupV1Limit(); err == nil {
+		return limit, nil
+	}
+	mem, err := psutil.VirtualMemory()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get system memory: %v", err)
+	}
+	return mem.Total, nil
+}


### PR DESCRIPTION
## What problem does this PR solve?
Fix memory limit detection logic for cgroupfs Close #8 Close #5 
fix: use ./memStress in exec.Command to avoid PATH not found error Close #7 

## What's changed and how it works?

- Fix memory limit detection logic for cgroup v1: treat 0x7FFFFFFFFFFFF000 (9223372036854771712) as unlimited.
- Ensure cgroup v2 uses "max" as unlimited.
- Update comments to English for better readability.
- This ensures memory stress respects container memory limits correctly.


## Related changes

- [x] This change also requires further updates to the ```chaos-mesh```

## Tests
- [x] Manual test

Note: A temporary --print-mem flag was added during development for testing purposes. It has been removed before finalizing the PR.

The situation where cgroup1 is restricted

![image](https://github.com/user-attachments/assets/84f183e6-9115-4845-a875-6b268f9854b6)

There are no restrictions on cgroup1
![image](https://github.com/user-attachments/assets/b1bcfbc8-9bf7-425a-8bfe-5a66d4f41831)
![image](https://github.com/user-attachments/assets/cd98c35a-634a-4ecd-9af9-80b9b34d1f2d)

(cgroup2) Docker container with a 32GB memory limit, result as follows (host has ~8GB physical memory):

![image](https://github.com/user-attachments/assets/736f95f9-e954-4151-aec2-3f08525ee7a9)
![image](https://github.com/user-attachments/assets/ef001de2-38d9-4e84-a0d5-0ecf2094c885)

(cgroup2) Docker container with a 10GB memory limit, result as follows (host has ~2GB physical memory):

![image](https://github.com/user-attachments/assets/04584dc4-7e2c-4106-a3d2-89bcb63449fc)
![image](https://github.com/user-attachments/assets/71206716-f57b-42bb-aa06-a7f7f8e0f441)

